### PR TITLE
Modified readme for laravel 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ $ composer require squareboat/sneaker
 
 ### Configure Laravel
 
-Once installation operation is complete, simply add the service provider to your project's `config/app.php` file:
+If you are using __laravel 5.5__ or higher you should skip the next step.
+
+If you are using laravel 5.3 or 5.4, simply add the service provider to your project's `config/app.php` file:
 
 #### Service Provider
 ```


### PR DESCRIPTION
I've modified the readme file for sneaker to fit the installation on laravel 5.5.

Because this package now supports auto package discovery it's no longer necessary to register the service provider manually.

Have a nice day,
Jordan