### PR TITLE
Added the ability to prohibit sending messages for all bots

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "illuminate/config": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
         "illuminate/mail": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
         "illuminate/log": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-        "symfony/debug": "~3.1|~3.2|~4.0"
+        "symfony/debug": "~3.1|~3.2|~4.0",
+        "jaybizzle/crawler-detect": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/sneaker.php
+++ b/config/sneaker.php
@@ -47,7 +47,10 @@ return [
     |
     | For which bots should we NOT send error emails?
     |
+    | To prohibit sending messages from all bots, specify `[*]`.
+    |
     */
+    //'ignored_bots' => ['*'],
     'ignored_bots' => [
         'yandexbot',        // YandexBot
         'googlebot',        // Googlebot

--- a/src/Sneaker.php
+++ b/src/Sneaker.php
@@ -3,9 +3,10 @@
 namespace SquareBoat\Sneaker;
 
 use Exception;
-use Psr\Log\LoggerInterface;
-use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Config\Repository;
+use Illuminate\Contracts\Mail\Mailer;
+use Jaybizzle\CrawlerDetect\CrawlerDetect;
+use Psr\Log\LoggerInterface;
 
 class Sneaker
 {
@@ -155,7 +156,7 @@ class Sneaker
      */
     private function isExceptionFromBot()
     {
-        $ignored_bots = $this->config->get('sneaker.ignored_bots');
+        $ignored_bots = (array) $this->config->get('sneaker.ignored_bots');
 
         $agent = array_key_exists('HTTP_USER_AGENT', $_SERVER)
                     ? strtolower($_SERVER['HTTP_USER_AGENT'])
@@ -163,6 +164,12 @@ class Sneaker
 
         if (is_null($agent)) {
             return false;
+        }
+
+        if (in_array('*', $ignored_bots)) {
+            $detect = new CrawlerDetect;
+
+            return $detect->isCrawler($agent);
         }
 
         foreach ($ignored_bots as $bot) {


### PR DESCRIPTION
In cases when it is necessary to prohibit sending email-messages for all bots, you will have to manually add them to the list. This is a problem, since you first need to add User-Agent collection mechanics to the application and find out which of them is a bot.
Thus, the best option would be to use a package that [specializes in defining bots](https://github.com/JayBizzle/Crawler-Detect).
As a result, we get the opportunity not only to specify which bots to ignore, but also to indicate ignore for all bots.

For example, here are the names of bots visiting one of my sites:
```
360Spider
AdBot
AdsBot
AhrefsBot
Apache-HttpClient/
Applebot
BacklinkCrawl
Baiduspider
bingbot
BingPreview
BLEXBot
bot
CCBot
Cliqzbot
Comparserbot
Crawl
curl
Dataprovider
developers.google.com/+/web/snippet/
Discordbot
DotBot
DuckDuckGo-Favicons-Bot
Exabot
ExtLinksBot
facebookexternalhit
fetch/1
fetcher
Genieo
Go-http-client
Google Favicon
Google Page Speed Insights
Google Web Preview
Google-Adwords
Google-Site-Verification
Googlebot
HeadlessChrome
HybridBot
ia_archiver
ips-agent
Java/
Jooblebot
LastModBot
LetsearchBot
linkdex
LinkpadBot
ltx71
Mail.RU
Mediapartners-Google
MegaIndex.ru
Microsoft Office
MJ12bot
MSIECrawl
Netcraft
Nimbostratus-Bot
oBot
okhttp
org_bot
PeoplePal
PhantomJS/
PHPCrawl
POE-Component-Client-HTTP
PRTG Network Monitor
PTST/17
PTST/181030
PTST/181031
PTST/181105
PTST/181115
PTST/181126
PTST/181206
PTST/181210
PTST/181214
PTST/181222
PTST/190107
PTST/190109
python-requests
Qwantify
Riddler
Robot
Scrapy
Screaming
SEMrush
SeopultContentAnalyzer
Site-Shot/
SiteCheckerBot
SkypeUriPreview
Slurp
SMTBot
Sogou web
spaziodati
special_archiver
StormCrawl
SurdotlyBot
TweetmemeBot
Uptimebot
Validator
vBSEO
VelenPublicWebCrawl
vkShare
W3C_Validator
WebCapture
WebCookies
weborama-fetcher
Webster
Wget
WhatsApp
WordPress/
WordupInfoSearch
Xenu Link Sleuth
YaDirectFetcher
Yandex
YisouSpider
zgrab
```

These bots are found in package [jaybizzle/crawler-detect](https://github.com/JayBizzle/Crawler-Detect).