### PR TITLE
Make queueing error mails configureable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ The package comes with `'silent' => true,` configuration by default, since you p
 
 For sending emails when an exception occurs set `SNEAKER_SILENT=false` in your `.env` file.
 
+#### should_queue
+
+By default we send error mails via laravel queue. Set this to `false` if you want disable this behavior
+
+```php
+'should_queue' => env('SNEAKER_SHOULD_QUEUE', true),
+```
+
+or set `SNEAKER_SHOULD_QUEUE=false` in your `.env` file.
 
 #### capture
 

--- a/config/sneaker.php
+++ b/config/sneaker.php
@@ -11,6 +11,16 @@ return [
     |
     */
     'silent' => env('SNEAKER_SILENT', true),
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Determine if we should queue the emails
+    |--------------------------------------------------------------------------
+    |
+    | Should we queue email error traces?
+    |
+    */
+    'should_queue' => env('SNEAKER_SHOULD_QUEUE', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/sneaker.php
+++ b/config/sneaker.php
@@ -17,7 +17,7 @@ return [
     | Determine if we should queue the emails
     |--------------------------------------------------------------------------
     |
-    | Should we queue email error traces?
+    | Should we queue error traces?
     |
     */
     'should_queue' => env('SNEAKER_SHOULD_QUEUE', true),

--- a/src/ExceptionMailer.php
+++ b/src/ExceptionMailer.php
@@ -7,7 +7,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-class ExceptionMailer extends Mailable implements ShouldQueue
+class ExceptionMailer extends Mailable
 {
     use Queueable, SerializesModels;
 

--- a/src/ExceptionMailer.php
+++ b/src/ExceptionMailer.php
@@ -5,7 +5,6 @@ namespace SquareBoat\Sneaker;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 class ExceptionMailer extends Mailable
 {

--- a/src/Sneaker.php
+++ b/src/Sneaker.php
@@ -102,13 +102,19 @@ class Sneaker
      */
     private function capture($exception)
     {
+        $shouldQueue = $this->config->get('sneaker.should_queue');
         $recipients = $this->config->get('sneaker.to');
 
         $subject = $this->handler->convertExceptionToString($exception);
 
         $body = $this->handler->convertExceptionToHtml($exception);
 
-        $this->mailer->to($recipients)->send(new ExceptionMailer($subject, $body));
+        $mail = new ExceptionMailer($subject, $body);
+        if ($shouldQueue) {
+            $this->mailer->to($recipients)->queue($mail);
+        } else {
+            $this->mailer->to($recipients)->send(new ExceptionMailer($subject, $body));
+        }
     }
 
     /**

--- a/src/Sneaker.php
+++ b/src/Sneaker.php
@@ -113,7 +113,7 @@ class Sneaker
         if ($shouldQueue) {
             $this->mailer->to($recipients)->queue($mail);
         } else {
-            $this->mailer->to($recipients)->send(new ExceptionMailer($subject, $body));
+            $this->mailer->to($recipients)->send($mail);
         }
     }
 


### PR DESCRIPTION
This PR (idea from #31) adds a new configuration option "should_queue" in the sneaker.php configuration file which determines if the error mail should be sent via the queue or not.