### PR TITLE
added support for configurable queue options

### DIFF
--- a/src/Mailables/AbstractExceptionMailer.php
+++ b/src/Mailables/AbstractExceptionMailer.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace SquareBoat\Sneaker;
+namespace SquareBoat\Sneaker\Mailables;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
-class ExceptionMailer extends Mailable implements ShouldQueue
+abstract class ExceptionMailer extends Mailable
 {
     use Queueable, SerializesModels;
 

--- a/src/Mailables/ExceptionMailer.php
+++ b/src/Mailables/ExceptionMailer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SquareBoat\Sneaker\Mailables;
+
+class ExceptionMailer extends AbstracktExceptionMailer
+{
+
+}

--- a/src/Mailables/QueueableExceptionMailer.php
+++ b/src/Mailables/QueueableExceptionMailer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SquareBoat\Sneaker\Mailables;
+
+class ExceptionMailer extends AbstracktExceptionMailer
+{ 
+    
+}

--- a/src/Sneaker.php
+++ b/src/Sneaker.php
@@ -102,13 +102,43 @@ class Sneaker
      */
     private function capture($exception)
     {
+        $queue = $this->config->get('sneaker.queue');
+
         $recipients = $this->config->get('sneaker.to');
 
         $subject = $this->handler->convertExceptionToString($exception);
 
         $body = $this->handler->convertExceptionToHtml($exception);
 
-        $this->mailer->to($recipients)->send(new ExceptionMailer($subject, $body));
+        $mail = $this->createMailable($subject, $body, $queue);
+
+        if ($queue['use']) {
+            $this->mailer->to($recipients)->queue($mail);
+        } else {
+            $this->mailer->to($recipients)->send($mail);
+        }
+    }
+
+    /**
+     * Create the mailable class. Either as queueable or ordinary.
+     * 
+     * @param string $subject
+     * @param string $body
+     * @param array $queue 
+     * 
+     * @return Illuminate\Mail\Mailable $mail
+     */
+    private function createMailable($subject, $body, $queue)
+    {
+        if ($queue['use']) {
+            $mail = (new Mailables\QueueableExceptionMailer($subject, $body))
+                ->onConnection($queue['conn'])
+                ->onQueue($queue['name']);
+        } else {
+            $mail = new Mailables\ExceptionMailer($subject, $body);
+        }
+
+        return $mail;
     }
 
     /**


### PR DESCRIPTION
I used the PR [#32](https://github.com/squareboat/sneaker/pull/32) as template. Splitted mailables into 3 classes for inhertiance and to difer between ShouldQueue-interface and none.
Added three values to ```config``` to determine all necessary values.