### PR TITLE
Update Sneak command to implement L7.x method

### DIFF
--- a/src/Commands/Sneak.php
+++ b/src/Commands/Sneak.php
@@ -58,7 +58,7 @@ class Sneak extends Command
 
             $this->info('Sneaker is working fine ✅');
         } catch (Exception $e) {
-            (new ConsoleApplication)->renderException($e, $this->output);
+            (new ConsoleApplication)->renderThrowable($e, $this->output);
         }
     }
 


### PR DESCRIPTION
The artisan sneaker:sneak command was broken in L7.x. The renderException method on the Console\Application class was renamed to renderThrowable.